### PR TITLE
check player object is valid before apply anything, on call backs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -73,21 +73,27 @@ armor_monoid.monoid = player_monoids.make_monoid({
 
 		join_handled[player:get_player_name()] = true
 
-		player:set_armor_groups(final)
+		if player then
+			player:set_armor_groups(final)
+		end
 	end,
 })
 
 
 -- If the monoid has not fired yet (or won't fire)
 minetest.register_on_joinplayer(function(player)
-	if not join_handled[player:get_player_name()] then
-		player:set_armor_groups(armor_groups)
+	if player then
+		if not join_handled[player:get_player_name()] then
+			player:set_armor_groups(armor_groups)
+		end
 	end
 end)
 
 
 minetest.register_on_leaveplayer(function(player)
+	if player then
 		join_handled[player:get_player_name()] = nil
+	end
 end)
 
 


### PR DESCRIPTION
the error was never really solved.. it's still in 5.3 and its just that is not happened so much anymore.. but still present in some servers..

* compatibility with minetest 0.4.17 and 5.0/5.2 for player object bug  minetest/minetest#8452