### PR TITLE
Add handling for immortal and fall_damage_add_percent armor groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,47 @@ armor_monoid.register_armor_group("arcane", 100)
 As you can see, the argument is not a multiplier, but the base armor group
 rating. Calling this would mean players start off with an armor rating in
 "arcane" of 100 (no protection).
+
+Special armor groups
+====================
+
+Luanti defines a number of [special armor groups](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md#objectref-armor-groups)
+that have an engine-based effect and therefore must be handled uniquely by this
+monoid.
+
+`fall_damage_add_percent`
+-------------------------
+
+The armor monoid handles this group exactly like normal armor groups that have a
+base value of 100, but because its value is multiplicative with built-in fall
+damage, its final value is internally offset by -100 to respect this behavior.
+
+To grant a player fall damage reduction, use the `fall_damage_add_percent` group
+as you would any normal damage group:
+
+```
+armor_monoid.monoid:add_change(player,{fall_damage_add_percent=0.5},"mymod:half_fall_damage")
+```
+
+`immortal`
+----------
+
+The armor monoid treats any value of 1 or less as an indication that a player
+can suffer damage. Conversely, any value greater than 1 will make a player
+immune to all damage.
+
+To grant a player immortality, set this group to a value greater than 1 like so:
+
+```
+armor_monoid.monoid:add_change(player,{immortal=2},"mymod:immortality")
+```
+
+Note that this is not in line with the typical use of the `immortal` armor
+group which usually has a value of 0 (not immortal) or 1 (immortal) due to the
+fact that armor monoid changes are multiplicative, so if the group is set to 0
+to revoke immortality, then no other changes can ever influence the armor group.
+
+This is largely a technical detail. If you use this mod to manage armor groups,
+then use a value of 1 or less to make a player mortal and a value greater than 1
+to make a player immortal. The internal implementation will translate these
+values to an actual armor group value of 0 or 1.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ damage, its final value is internally offset by -100 to respect this behavior.
 To grant a player fall damage reduction, use the `fall_damage_add_percent` group
 as you would any normal damage group:
 
-```
+```lua
 armor_monoid.monoid:add_change(player,{fall_damage_add_percent=0.5},"mymod:half_fall_damage")
 ```
 
@@ -60,7 +60,7 @@ immune to all damage.
 
 To grant a player immortality, set this group to a value greater than 1 like so:
 
-```
+```lua
 armor_monoid.monoid:add_change(player,{immortal=2},"mymod:immortality")
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,21 @@ monoid.
 `fall_damage_add_percent`
 -------------------------
 
-The armor monoid handles this group exactly like normal armor groups that have a
-base value of 100, but because its value is multiplicative with built-in fall
-damage, its final value is internally offset by -100 to respect this behavior.
+The `fall_damage_add_percent` armor group controls how much additional damage
+that a player will incur when falling from a high height. The armor monoid
+handles this group exactly like normal armor groups that have a base value of
+100.
+
+The armor monoid uses the following range of values for the
+`fall_damage_add_percent` armor group:
+
+- `value = 100`: player takes normal fall damage (100%)
+- `value = 0`: player takes no fall damage (0%)
+- `value = X`: player takes X% less fall damage (1%-99%)
+- default value: 100
 
 To grant a player fall damage reduction, use the `fall_damage_add_percent` group
-as you would any normal damage group:
+as you would any normal armor group:
 
 ```lua
 armor_monoid.monoid:add_change(player,{fall_damage_add_percent=0.5},"mymod:half_fall_damage")
@@ -54,22 +63,18 @@ armor_monoid.monoid:add_change(player,{fall_damage_add_percent=0.5},"mymod:half_
 `immortal`
 ----------
 
-The armor monoid treats any value of 1 or less as an indication that a player
-can suffer damage. Conversely, any value greater than 1 will make a player
-immune to all damage.
+The `immortal` armor group controls whether or not a player can suffer damage
+and experience drowning. Due to limitations of this monoid, the values of this
+armor group are handled differently than most armor groups.
+
+The armor monoid uses the following values for the `immortal` armor group:
+
+- `value <= 1`: player is not immortal, subject to damage and drowning
+- `value > 1`: player is immortal, will not suffer damage and cannot drown
+- default value: 1
 
 To grant a player immortality, set this group to a value greater than 1 like so:
 
 ```lua
 armor_monoid.monoid:add_change(player,{immortal=2},"mymod:immortality")
 ```
-
-Note that this is not in line with the typical use of the `immortal` armor
-group which usually has a value of 0 (not immortal) or 1 (immortal) due to the
-fact that armor monoid changes are multiplicative, so if the group is set to 0
-to revoke immortality, then no other changes can ever influence the armor group.
-
-This is largely a technical detail. If you use this mod to manage armor groups,
-then use a value of 1 or less to make a player mortal and a value greater than 1
-to make a player immortal. The internal implementation will translate these
-values to an actual armor group value of 0 or 1.

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,11 @@
 
 armor_monoid = {}
 
-local armor_groups = { fleshy = 100 }
+local armor_groups = {
+	fleshy = 100,
+	fall_damage_add_percent = 100,
+	immortal = 1,
+}
 
 armor_monoid.registered_groups = armor_groups
 
@@ -70,6 +74,15 @@ armor_monoid.monoid = player_monoids.make_monoid({
 				final[k] = final[k] * v
 			end
 		end
+
+		-- fall_damage_add_percent is a special armor group that has an inherent
+		-- value of 0 rather than 100, so its final value is offset by -100 here
+		final.fall_damage_add_percent = final.fall_damage_add_percent - 100
+
+		-- immortal is a special armor group that must be either 0 or 1 to indicate
+		-- mortality or immortality, respectively, so its final value is constrained
+		-- here
+		final.immortal = final.immortal > 1 and 1 or 0
 
 		join_handled[player:get_player_name()] = true
 


### PR DESCRIPTION
The Luanti engine defines two [special armor groups](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md#objectref-armor-groups) that affect players: `immortal` and `fall_damage_add_percent`. As it stands, using Armor Monoid will cause these groups to be removed from players' armor groups when changes are applied which means these groups can never be set or changed persistently while Armor Monoid is active.

This pull request adds special handling for these armor groups, ensuring that their default values will remain as they are while also allowing mods to manage these groups via Armor Monoid.

The implementation for `fall_damage_add_percent` is fairly intuitive, but the implementation for `immortal` is a little strange due to the fact that a default value of 0 means that Armor Monoid could never change this value due to multiplication by 0 always yielding 0. This implementation thus translates a value of 1 or less to 0 and a value greater than 1 to 1 which allows for correct and concurrent changes to this value.

I've done extensive testing in Asuna and in Minetest Game to ensure that the logic works as expected.